### PR TITLE
update include_tasks syntax in tasks/main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - block:
 
   - name: include groups tasks
-    include: "{{ net_acl_include }}"
+    include_tasks: "{{ net_acl_include }}"
     with_first_found:
       - "type/iptables.yml"
     loop_control:


### PR DESCRIPTION
This is a compatibility update for recent versions of ansible where include has been replace with include_tasks